### PR TITLE
fix: remove "self_bot" kwarg

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ class UniBot(Bot):
         intents.messages = True
         intents.emojis = True
         intents.bans = True
-        super().__init__(command_prefix="$", self_bot=True, help_command=None, intents=intents)
+        super().__init__(command_prefix="$", help_command=None, intents=intents)
 
     async def on_ready(self):
         self.load_extension("cogs.admin")


### PR DESCRIPTION
The "self_bot" kwarg in the super() call has only been used for bots running on actual clients - or at least that is only what I have seen so far - so I decided to remove this kwarg.